### PR TITLE
Implement queue limit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ log_root = "/var/log/hookshot"
 ## outgoing webhook requests so a consumer can create complete URLs.
 hostname = "10.20.30.40"
 
+## The number of items to limit any given queue. Any items that get added after
+## the limit has been reached will bump the oldest item from the queue. For an
+## unlimited queue length, comment out or remove this configuration line.
+queue_limit = 1
+
 ## `env.*` sections are optional. They represent extra data that will be sent to
 ## repositories that might need extra that shouldn't be stored in the repository
 ## configuration or embedded in the make or ansible tasks.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -111,7 +111,7 @@ pub fn main() {
 #[allow(unused_must_use)]
 fn start_server(config: ServerConfig) {
     let mut router = Router::new();
-    let global_manager = Arc::new(Mutex::new(TaskManager::new()));
+    let global_manager = Arc::new(Mutex::new(TaskManager::new(config.queue_limit)));
 
     // Create a healthcheck endpoint.
     router.get("/health", move |_: &mut Request| {

--- a/src/deploy_task.rs
+++ b/src/deploy_task.rs
@@ -38,6 +38,17 @@ pub struct DeployTask {
     pub secret: String,
 }
 impl Runnable for DeployTask {
+    fn cancel(&self) {
+        let task_id = self.id.to_string();
+        let logfile_path = Path::new(&self.logdir).join(format!("{}.log", task_id));
+        let mut logger = match LogWriter::new(&logfile_path) {
+            Ok(logfile) => logfile,
+            Err(_) => return println!("[{}]: could not open logfile for writing", &task_id),
+        };
+        // Log the current user
+        logger.write("task cancelled");
+    }
+
 
     // TODO: this is a god damn mess and seriously needs to be refactored,
     // especially all of the logging.


### PR DESCRIPTION
This allows the administrator to set a hard queue limit in the hookshot
server configuration. Any new items that get added to the queue after
the limit has been reached bump off the oldest task scheduled.

For example, if we have a queue limit of 5 and a queue that looks like this:

```
<---
1 2 3 4 5
```

when a new task gets added the queue will look like this:

```
<---
2 3 4 5 6
```

If a task gets bumped from the queue the `cancel()` method will called
on that task.
